### PR TITLE
feat: added stale issue/pr GHA workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,30 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '15 7 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-issue-stale: 60
+        days-before-pr-stale: 30
+        days-before-issue-close: 365
+        days-before-pr-close: -1
+        stale-issue-message: 'This issue is stale because it has been open 60 days with no activity.'
+        stale-issue-label: 'lifecycle/stale'
+        stale-pr-message: 'This PR is stale because it has been open 30 days with no activity.'
+        stale-pr-label: 'lifecycle/stale'
+        close-issue-message: 'This issue was closed because it has been stalled for 365 days with no activity.'
+        close-issue-label: 'lifecycle/rotten'
+        exempt-issue-labels: 'lifecycle/frozen'
+        exempt-pr-labels: 'lifecycle/frozen'


### PR DESCRIPTION
**What this PR does / why we need it**:

Added new GitHub actions workflow to mark issues and PRs as stale and to
automatically close issues.

The lables used are inline with those from the kubernetes project.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #86 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
NONE
```